### PR TITLE
API 추가 및 회원가입/로그인 기능 구현

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,6 +17,7 @@ module.exports = {
   plugins: ['react', 'react-hooks', 'import'],
   rules: {
     'react/function-component-definition': 'off',
+    'import/no-extraneous-dependencies': 'off',
     'import/prefer-default-export': 'off',
     'react/prop-types': 'off',
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "axios": "^1.3.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.10.0",
@@ -5092,6 +5093,29 @@
       "integrity": "sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.5.tgz",
+      "integrity": "sha512-glL/PvG/E+xCWwV8S6nCHcrfg1exGx7vxyUIivIA1iL7BIh6bePylCfVHwp6k13ao7SATxB6imau2kqY+I67kw==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -14612,6 +14636,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/psl": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^1.3.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.10.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,29 +1,40 @@
 import React from 'react';
-import { RouterProvider, createBrowserRouter } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom';
 import Signup from './pages/singup/Signup';
 import Signin from './pages/signin/Singin';
 import Todo from './pages/todo/Todo';
+import RequireAuth from './components/layout/RequireAuth';
+import NoRequireAuth from './components/layout/NoRequireAuth';
+import Home from './pages/home/home';
 
-const router = createBrowserRouter([
-  {
-    path: '/',
-    element: <p>Home</p>,
-    errorElement: <p>Not Found</p>,
-  },
-  {
-    path: '/signup',
-    element: <Signup />,
-  },
-  {
-    path: '/signin',
-    element: <Signin />,
-  },
-  {
-    path: '/todo',
-    element: <Todo />,
-  },
-]);
-
-const App = () => <RouterProvider router={router} />;
+const App = () => (
+  <Routes>
+    <Route path="*" element={<Home />} />
+    <Route
+      path="/signup"
+      element={
+        <NoRequireAuth>
+          <Signup />
+        </NoRequireAuth>
+      }
+    />
+    <Route
+      path="/signin"
+      element={
+        <NoRequireAuth>
+          <Signin />
+        </NoRequireAuth>
+      }
+    />
+    <Route
+      path="/todo"
+      element={
+        <RequireAuth>
+          <Todo />
+        </RequireAuth>
+      }
+    />
+  </Routes>
+);
 
 export default App;

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,12 +1,13 @@
 import axios from 'axios';
 import { getStorage } from '../utils/storage';
+import { JWT_TOKEN } from '../consts/localStorage';
 
 const BASE_URL = 'https://www.pre-onboarding-selection-task.shop/';
 
 const setInstanceHeaders = (instance) => {
   instance.interceptors.request.use(
     (config) => {
-      const token = getStorage('jwt_token');
+      const token = getStorage(JWT_TOKEN);
       return {
         ...config,
         headers: {
@@ -24,10 +25,7 @@ const baseApi = (url, options) => {
 };
 
 const authApi = (url, options) => {
-  const instance = axios.create({
-    baseURL: url,
-    ...options,
-  });
+  const instance = axios.create({ baseURL: url, ...options });
   setInstanceHeaders(instance);
   return instance;
 };

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,0 +1,36 @@
+import axios from 'axios';
+import { getStorage } from '../utils/storage';
+
+const BASE_URL = 'https://www.pre-onboarding-selection-task.shop/';
+
+const setInstanceHeaders = (instance) => {
+  instance.interceptors.request.use(
+    (config) => {
+      const token = getStorage('jwt_token');
+      return {
+        ...config,
+        headers: {
+          authorization: token ? `bearer ${token}` : null,
+        },
+      };
+    },
+    (error) => Promise.reject(error.response)
+  );
+};
+
+const baseApi = (url, options) => {
+  const instance = axios.create({ baseURL: url, ...options });
+  return instance;
+};
+
+const authApi = (url, options) => {
+  const instance = axios.create({
+    baseURL: url,
+    ...options,
+  });
+  setInstanceHeaders(instance);
+  return instance;
+};
+
+export const baseInstance = baseApi(BASE_URL);
+export const authInstance = authApi(BASE_URL);

--- a/src/api/signin/signin.js
+++ b/src/api/signin/signin.js
@@ -1,0 +1,11 @@
+import { baseInstance } from '..';
+
+export const signin = async (userInfo) => {
+  try {
+    const { data } = await baseInstance.post('/auth/signin', userInfo);
+    return data;
+  } catch (error) {
+    console.error(error);
+  }
+  return null;
+};

--- a/src/api/signup/signup.js
+++ b/src/api/signup/signup.js
@@ -1,0 +1,11 @@
+import { baseInstance } from '..';
+
+export const signup = async (userInfo) => {
+  try {
+    const { data } = await baseInstance.post('/auth/signup', userInfo);
+    return data;
+  } catch (error) {
+    console.error(error);
+  }
+  return null;
+};

--- a/src/api/todo/todo.js
+++ b/src/api/todo/todo.js
@@ -1,0 +1,41 @@
+import { authInstance } from '..';
+
+export const createTodo = async (todo) => {
+  try {
+    const { data } = await authInstance.post('/todos', todo);
+    return data;
+  } catch (error) {
+    console.error(error);
+  }
+  return null;
+};
+
+export const getTodos = async () => {
+  try {
+    const { data } = await authInstance.get('/todos');
+    return data;
+  } catch (error) {
+    console.error(error);
+  }
+  return null;
+};
+
+export const updateTodo = async (id, todo) => {
+  try {
+    const { data } = await authInstance.get(`/todos/:${id}`, todo);
+    return data;
+  } catch (error) {
+    console.error(error);
+  }
+  return null;
+};
+
+export const deleteTodo = async (id) => {
+  try {
+    const { data } = await authInstance.get(`/todos/:${id}`);
+    return data;
+  } catch (error) {
+    console.error(error);
+  }
+  return null;
+};

--- a/src/api/todo/todo.js
+++ b/src/api/todo/todo.js
@@ -22,7 +22,7 @@ export const getTodos = async () => {
 
 export const updateTodo = async (id, todo) => {
   try {
-    const { data } = await authInstance.get(`/todos/:${id}`, todo);
+    const { data } = await authInstance.put(`/todos/:${id}`, todo);
     return data;
   } catch (error) {
     console.error(error);
@@ -32,7 +32,7 @@ export const updateTodo = async (id, todo) => {
 
 export const deleteTodo = async (id) => {
   try {
-    const { data } = await authInstance.get(`/todos/:${id}`);
+    const { data } = await authInstance.delete(`/todos/:${id}`);
     return data;
   } catch (error) {
     console.error(error);

--- a/src/components/layout/NoRequireAuth.jsx
+++ b/src/components/layout/NoRequireAuth.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import useAuth from '../../hooks/useAuth';
+
+const NoRequireAuth = ({ children }) => {
+  const auth = useAuth();
+
+  if (auth) {
+    return <Navigate to="/todo" replace />;
+  }
+
+  return children;
+};
+
+export default NoRequireAuth;

--- a/src/components/layout/RequireAuth.jsx
+++ b/src/components/layout/RequireAuth.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import useAuth from '../../hooks/useAuth';
+
+const RequireAuth = ({ children }) => {
+  const auth = useAuth();
+
+  if (!auth) {
+    return <Navigate to="/signin" replace />;
+  }
+
+  return children;
+};
+
+export default RequireAuth;

--- a/src/consts/localStorage.js
+++ b/src/consts/localStorage.js
@@ -1,0 +1,1 @@
+export const JWT_TOKEN = 'JWT_TOKEN';

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -1,0 +1,9 @@
+import { JWT_TOKEN } from '../consts/localStorage';
+import { getStorage } from '../utils/storage';
+
+const useAuth = () => {
+  const token = getStorage(JWT_TOKEN);
+  return token;
+};
+
+export default useAuth;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>
 );

--- a/src/pages/home/home.jsx
+++ b/src/pages/home/home.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import useAuth from '../../hooks/useAuth';
+
+const Home = () => {
+  const auth = useAuth();
+
+  if (!auth) {
+    return <Navigate to="/signin" replace />;
+  }
+  return <Navigate to="/todo" replace />;
+};
+
+export default Home;

--- a/src/pages/signin/hooks/useSingin.js
+++ b/src/pages/signin/hooks/useSingin.js
@@ -6,25 +6,24 @@ import { setStorage } from '../../../utils/storage';
 const useSignin = () => {
   const navigate = useNavigate();
 
-  const handleSignin = async (e) => {
-    e.preventDefault();
-    const [email, password] = e.target.elements;
+  const handleSignin = async (event) => {
+    event.preventDefault();
+
+    const [email, password] = event.target.elements;
     const userInfo = {
       email: email.value,
       password: password.value,
     };
-    const { accesToken } = await signin(userInfo);
 
-    if (accesToken !== null) {
+    const { accesToken } = await signin(userInfo);
+    if (!accesToken) {
       setStorage(JWT_TOKEN, accesToken);
-      return navigate('/todo');
+      return navigate('/todo', { replace: true });
     }
     return null;
   };
 
-  return {
-    handleSignin,
-  };
+  return { handleSignin };
 };
 
 export default useSignin;

--- a/src/pages/signin/hooks/useSingin.js
+++ b/src/pages/signin/hooks/useSingin.js
@@ -1,8 +1,25 @@
+import { useNavigate } from 'react-router-dom';
+import { signin } from '../../../api/signin/signin';
+import { JWT_TOKEN } from '../../../consts/localStorage';
+import { setStorage } from '../../../utils/storage';
+
 const useSignin = () => {
-  const handleSignin = (e) => {
+  const navigate = useNavigate();
+
+  const handleSignin = async (e) => {
     e.preventDefault();
     const [email, password] = e.target.elements;
-    console.log(email.value, password.value);
+    const userInfo = {
+      email: email.value,
+      password: password.value,
+    };
+    const { accesToken } = await signin(userInfo);
+
+    if (accesToken !== null) {
+      setStorage(JWT_TOKEN, accesToken);
+      return navigate('/todo');
+    }
+    return null;
   };
 
   return {

--- a/src/pages/singup/hooks/useSignup.js
+++ b/src/pages/singup/hooks/useSignup.js
@@ -1,8 +1,23 @@
+import { useNavigate } from 'react-router-dom';
+import { signup } from '../../../api/signup/signup';
+
 const useSignup = () => {
-  const handleSignup = (e) => {
+  const navigate = useNavigate();
+
+  const handleSignup = async (e) => {
     e.preventDefault();
     const [email, password] = e.target.elements;
-    console.log(email.value, password.value);
+    const userInfo = {
+      email: email.value,
+      password: password.value,
+    };
+
+    const rs = await signup(userInfo);
+
+    if (rs !== null) {
+      return navigate('/signin');
+    }
+    return null;
   };
 
   return {

--- a/src/pages/singup/hooks/useSignup.js
+++ b/src/pages/singup/hooks/useSignup.js
@@ -4,25 +4,23 @@ import { signup } from '../../../api/signup/signup';
 const useSignup = () => {
   const navigate = useNavigate();
 
-  const handleSignup = async (e) => {
-    e.preventDefault();
-    const [email, password] = e.target.elements;
+  const handleSignup = async (event) => {
+    event.preventDefault();
+
+    const [email, password] = event.target.elements;
     const userInfo = {
       email: email.value,
       password: password.value,
     };
 
     const rs = await signup(userInfo);
-
-    if (rs !== null) {
-      return navigate('/signin');
+    if (!rs) {
+      return navigate('/signin', { replace: true });
     }
     return null;
   };
 
-  return {
-    handleSignup,
-  };
+  return { handleSignup };
 };
 
 export default useSignup;

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -1,0 +1,9 @@
+export const setStorage = (key, value) => {
+  if (typeof window === 'undefined') return null;
+  return localStorage.setItem(key, value);
+};
+
+export const getStorage = (key) => {
+  if (typeof window === 'undefined') return null;
+  return localStorage.getItem(key);
+};


### PR DESCRIPTION
- axios api 모듈 추가
- 로그인 및 회원가입 api 연결
- 회원가입 성공 시, 로그인 페이지로 리다이렉트 되는 기능 추가
- 로그인 성공 시, todo 페이지로 리다이렉트 되는 기능 추가
- 로그인 성공 시, 응답받은 JWT 토큰 로컬 스토리지에 저장하는 기능 추가
- 로그인 여부에 따른 리다이렉트 처리를 구현
  - 로컬 스토리지에 토큰이 있는 상태로 /signin 또는 /signup 페이지에 접속한다면 /todo 경로로 리다이렉트
  - 로컬 스토리지에 토큰이 없는 상태로 /todo페이지에 접속한다면 /signin 경로로 리다이렉트